### PR TITLE
[FIX] text builder parsing linebreaks

### DIFF
--- a/bodies/example_body.txt
+++ b/bodies/example_body.txt
@@ -2,7 +2,7 @@
 <html>
     <body>
         <div style="padding:20px 0px">
-            <div style="text-align:left;">
+            <div style="text-align:left; white-space: pre-wrap;">
                 <p>
                 Dear {addressee},
                 </p>


### PR DESCRIPTION
Quick fix to update the example body to include the HTML for parsing linebreak elements nicely by including an example of use.

This FIX is less impactful now in the shadow of a previous commit. 